### PR TITLE
Fix: Autocomplete attribute not working

### DIFF
--- a/goAlfred.go
+++ b/goAlfred.go
@@ -45,7 +45,7 @@ type AlfredResult struct {
 	Sub      string   `xml:"subtitle"`
 	Icon     string   `xml:"icon"`
 	Valid    string   `xml:"valid,attr"`
-	Auto     string   `xml:"auto,attr"`
+	Auto     string   `xml:"autocomplete,attr"`
 	Rtype    string   `xml:"type,attr,omitempty"`
 	Priority int      `xml:"omit"`
 }


### PR DESCRIPTION
For reference: [Help and Support > Workflows > Inputs > Script Filter](https://www.alfredapp.com/help/workflows/inputs/script-filter/#xml)
