### PR TITLE
Check for missing environment variable

### DIFF
--- a/goAlfred.go
+++ b/goAlfred.go
@@ -91,6 +91,14 @@ func init() {
 	cache = os.Getenv("alfred_workflow_cache")
 	data = os.Getenv("alfred_workflow_data")
 
+	if cache == "" {
+		log.Fatalf("Environment variable alfred_workflow_cache not set")
+	}
+
+	if data == "" {
+		log.Fatalf("Environment variable alfred_workflow_data not set")
+	}
+
 	//
 	// See if the cache directory exists.
 	//

--- a/goAlfred.go
+++ b/goAlfred.go
@@ -102,7 +102,7 @@ func init() {
 	//
 	// See if the cache directory exists.
 	//
-	if _, err := os.Stat(cache); os.IsNotExist(err) {
+	if _, err = os.Stat(cache); os.IsNotExist(err) {
 		//
 		// The cache directory does not exist. Create it.
 		//


### PR DESCRIPTION
This is a result of my attempt to run an Alfred workflow via the command-line to troubleshoot an issue. Without this check, I got an obscure "Unable to mkdir" error, as it was attempting to make a null directory.

The other change is a simple "do what go lint" says, as recreating the 'err' variable is unnecessary.

Thank you!